### PR TITLE
Add Login and create Note feature

### DIFF
--- a/src/screens/Login/index.css
+++ b/src/screens/Login/index.css
@@ -1,0 +1,12 @@
+@media all and (min-width: 480px) {
+  .Login {
+    padding: 60px 0;
+  }
+
+  .Login form {
+    margin: 0 auto;
+    max-width: 320px;
+  }
+}
+
+  

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -8,7 +8,7 @@ import { Auth } from 'aws-amplify';
 import LoaderButton from '../../components/LoaderButton';
 import "./index.css";
 
-class Signup extends Component {
+class Login extends Component {
   constructor(props) {
     super(props);
 
@@ -88,4 +88,4 @@ class Signup extends Component {
   }
 }
 
-export default Signup;
+export default Login;

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -20,10 +20,8 @@ class Login extends Component {
   }
 
   validateForm() {
-    return (
-      this.state.email.length > 0 &&
-      this.state.password.length > 0
-    );
+    const { email, password } = this.state;
+    return email && password;
   }
 
   handleChange = event => {
@@ -53,6 +51,7 @@ class Login extends Component {
   }
 
   render() {
+    const { email, password, isLoading } = this.state;
     return (
       <div className="Login">
         <form onSubmit={this.handleSubmit}>
@@ -61,14 +60,14 @@ class Login extends Component {
             <FormControl
               autoFocus
               type="email"
-              value={this.state.email}
+              value={email}
               onChange={this.handleChange}
             />
           </FormGroup>
           <FormGroup controlId="password" bsSize="large">
             <ControlLabel>Password</ControlLabel>
             <FormControl
-              value={this.state.password}
+              value={password}
               onChange={this.handleChange}
               type="password"
             />
@@ -78,7 +77,7 @@ class Login extends Component {
             bsSize="large"
             disabled={!this.validateForm()}
             type="submit"
-            isLoading={this.state.isLoading}
+            isLoading={isLoading}
             text="Login"
             loadingText="Logging in…"
           />

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -1,0 +1,91 @@
+import React, { Component } from "react";
+import {
+  FormGroup,
+  FormControl,
+  ControlLabel
+} from "react-bootstrap";
+import { Auth } from 'aws-amplify';
+import LoaderButton from '../../components/LoaderButton';
+import "./index.css";
+
+class Signup extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isLoading: false,
+      email: "",
+      password: "",
+    };
+  }
+
+  validateForm() {
+    return (
+      this.state.email.length > 0 &&
+      this.state.password.length > 0
+    );
+  }
+
+  handleChange = event => {
+    this.setState({
+      [event.target.id]: event.target.value
+    });
+  }
+
+  handleSubmit = async event => {
+    event.preventDefault();
+
+    this.setState({ isLoading: true });
+
+    try {
+      const { history, userHasAuthenticated } = this.props;
+      await Auth.signIn({
+        username: this.state.email,
+        password: this.state.password
+      });
+      userHasAuthenticated(true);
+      history.push('/');
+    } catch (e) {
+      alert(e.message);
+    }
+
+    this.setState({ isLoading: false });
+  }
+
+  render() {
+    return (
+      <div className="Login">
+        <form onSubmit={this.handleSubmit}>
+          <FormGroup controlId="email" bsSize="large">
+            <ControlLabel>Email</ControlLabel>
+            <FormControl
+              autoFocus
+              type="email"
+              value={this.state.email}
+              onChange={this.handleChange}
+            />
+          </FormGroup>
+          <FormGroup controlId="password" bsSize="large">
+            <ControlLabel>Password</ControlLabel>
+            <FormControl
+              value={this.state.password}
+              onChange={this.handleChange}
+              type="password"
+            />
+          </FormGroup>
+          <LoaderButton
+            block
+            bsSize="large"
+            disabled={!this.validateForm()}
+            type="submit"
+            isLoading={this.state.isLoading}
+            text="Login"
+            loadingText="Logging in…"
+          />
+        </form>
+      </div>
+    );
+  }
+}
+
+export default Signup;

--- a/src/screens/NoteDetail/index.tsx
+++ b/src/screens/NoteDetail/index.tsx
@@ -134,15 +134,16 @@ class NoteDetail extends Component {
 
   render() {
     const { isNew } = this.props;
-    const { attachment } = this.state.note || {};
+    const { note, content, attachmentURL, isLoading, isDeleting } = this.state;
+    const { attachment } = note || {};
     return (
       <div className="NoteDetail">
-        {(this.state.note || isNew) &&
+        {(note || isNew) &&
           <form onSubmit={this.handleSubmit}>
             <FormGroup controlId="content">
               <FormControl
                 onChange={this.handleChange}
-                value={this.state.content}
+                value={content}
                 componentClass="textarea"
               />
             </FormGroup>
@@ -153,7 +154,7 @@ class NoteDetail extends Component {
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={this.state.attachmentURL}
+                    href={attachmentURL}
                   >
                     {this.formatFilename(attachment)}
                   </a>
@@ -170,7 +171,7 @@ class NoteDetail extends Component {
               bsSize="large"
               disabled={!this.validateForm()}
               type="submit"
-              isLoading={this.state.isLoading}
+              isLoading={isLoading}
               text={isNew ? "Create" : "Save"}
               loadingText="Saving…"
             />
@@ -178,7 +179,7 @@ class NoteDetail extends Component {
               block
               bsStyle="danger"
               bsSize="large"
-              isLoading={this.state.isDeleting}
+              isLoading={isDeleting}
               onClick={this.handleDelete}
               text="Delete"
               loadingText="Deleting…"

--- a/src/screens/NoteDetail/index.tsx
+++ b/src/screens/NoteDetail/index.tsx
@@ -22,6 +22,9 @@ class NoteDetail extends Component {
   }
 
   async componentDidMount() {
+    if (this.props.isNew) {
+      return;
+    }
     try {
       let attachmentURL;
       const note = await this.getNote();
@@ -46,6 +49,11 @@ class NoteDetail extends Component {
   }
 
   saveNote(note) {
+    if (this.props.isNew) {
+      return API.post("notes", '/notes', {
+        body: note
+      });
+    }
     return API.put("notes", `/notes/${this.props.match.params.id}`, {
       body: note
     });
@@ -125,9 +133,11 @@ class NoteDetail extends Component {
   }
 
   render() {
+    const { isNew } = this.props;
+    const { attachment } = this.state.note || {};
     return (
       <div className="NoteDetail">
-        {this.state.note &&
+        {(this.state.note || isNew) &&
           <form onSubmit={this.handleSubmit}>
             <FormGroup controlId="content">
               <FormControl
@@ -136,7 +146,7 @@ class NoteDetail extends Component {
                 componentClass="textarea"
               />
             </FormGroup>
-            {this.state.note.attachment &&
+            {attachment &&
               <FormGroup>
                 <ControlLabel>Attachment</ControlLabel>
                 <FormControl.Static>
@@ -145,12 +155,12 @@ class NoteDetail extends Component {
                     rel="noopener noreferrer"
                     href={this.state.attachmentURL}
                   >
-                    {this.formatFilename(this.state.note.attachment)}
+                    {this.formatFilename(attachment)}
                   </a>
                 </FormControl.Static>
               </FormGroup>}
             <FormGroup controlId="file">
-              {!this.state.note.attachment &&
+              {!attachment &&
                 <ControlLabel>Attachment</ControlLabel>}
               <FormControl onChange={this.handleFileChange} type="file" />
             </FormGroup>
@@ -161,10 +171,10 @@ class NoteDetail extends Component {
               disabled={!this.validateForm()}
               type="submit"
               isLoading={this.state.isLoading}
-              text="Save"
+              text={isNew ? "Create" : "Save"}
               loadingText="Saving…"
             />
-            <LoaderButton
+            {!isNew && <LoaderButton
               block
               bsStyle="danger"
               bsSize="large"
@@ -172,7 +182,7 @@ class NoteDetail extends Component {
               onClick={this.handleDelete}
               text="Delete"
               loadingText="Deleting…"
-            />
+            />}
           </form>}
       </div>
     );

--- a/src/screens/Root.tsx
+++ b/src/screens/Root.tsx
@@ -7,6 +7,7 @@ import Navigation from '../components/Navigation';
 import Home from './Home';
 import NoteDetail from './NoteDetail';
 import Signup from './Signup';
+import Login from './Login';
 import NotFound from './NotFound';
 
 const ScreensRoot = ({ childProps }) => (
@@ -14,7 +15,9 @@ const ScreensRoot = ({ childProps }) => (
     <AppliedRoute component={Navigation} props={childProps} />
     <Switch>
       <AppliedRoute exact path="/" component={Home} props={childProps} />
+      <UnauthenticatedRoute path="/login" exact component={Login} props={childProps} />
       <UnauthenticatedRoute path="/signup" exact component={Signup} props={childProps} />
+      <AuthenticatedRoute path="/notes/new" exact component={NoteDetail} props={{...childProps, isNew: true}} />
       <AuthenticatedRoute path="/notes/:id" exact component={NoteDetail} props={childProps} />
       <Route component={NotFound} />
     </Switch>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -24,10 +24,11 @@ class Signup extends Component {
   }
 
   validateForm() {
+    const { email, password, confirmPassword } = this.state;
     return (
-      this.state.email.length > 0 &&
-      this.state.password.length > 0 &&
-      this.state.password === this.state.confirmPassword
+      email.length > 0 &&
+      password.length > 0 &&
+      password === confirmPassword
     );
   }
 
@@ -62,16 +63,18 @@ class Signup extends Component {
   }
 
   handleConfirmationSubmit = async event => {
+    const { email, confirmationCode, password } = this.state;
+    const { history, userHasAuthenticated} = this.props;
     event.preventDefault();
 
     this.setState({ isLoading: true });
 
     try {
-      await Auth.confirmSignUp(this.state.email, this.state.confirmationCode);
-      await Auth.signIn(this.state.email, this.state.password);
+      await Auth.confirmSignUp(email, confirmationCode);
+      await Auth.signIn(email, password);
 
-      this.props.userHasAuthenticated(true);
-      this.props.history.push("/");
+      userHasAuthenticated(true);
+      history.push("/");
     } catch(e) {
       alert(e.message);
       this.setState({ isLoading: false });
@@ -79,6 +82,7 @@ class Signup extends Component {
   }
 
   renderConfirmationForm() {
+    const { confirmationCode, isLoading } = this.state;
     return (
       <form onSubmit={this.handleConfirmationSubmit}>
         <FormGroup controlId="confirmationCode" bsSize="large">
@@ -86,7 +90,7 @@ class Signup extends Component {
           <FormControl
             autoFocus
             type="tel"
-            value={this.state.confirmationCode}
+            value={confirmationCode}
             onChange={this.handleChange}
           />
           <HelpBlock>Please check your email for the code.</HelpBlock>
@@ -96,7 +100,7 @@ class Signup extends Component {
           bsSize="large"
           disabled={!this.validateConfirmationForm()}
           type="submit"
-          isLoading={this.state.isLoading}
+          isLoading={isLoading}
           text="Verify"
           loadingText="Verifying…"
         />
@@ -105,6 +109,7 @@ class Signup extends Component {
   }
 
   renderForm() {
+    const { email, password, confirmPassword, isLoading } = this.state;
     return (
       <form onSubmit={this.handleSubmit}>
         <FormGroup controlId="email" bsSize="large">
@@ -112,14 +117,14 @@ class Signup extends Component {
           <FormControl
             autoFocus
             type="email"
-            value={this.state.email}
+            value={email}
             onChange={this.handleChange}
           />
         </FormGroup>
         <FormGroup controlId="password" bsSize="large">
           <ControlLabel>Password</ControlLabel>
           <FormControl
-            value={this.state.password}
+            value={password}
             onChange={this.handleChange}
             type="password"
           />
@@ -127,7 +132,7 @@ class Signup extends Component {
         <FormGroup controlId="confirmPassword" bsSize="large">
           <ControlLabel>Confirm Password</ControlLabel>
           <FormControl
-            value={this.state.confirmPassword}
+            value={confirmPassword}
             onChange={this.handleChange}
             type="password"
           />
@@ -137,7 +142,7 @@ class Signup extends Component {
           bsSize="large"
           disabled={!this.validateForm()}
           type="submit"
-          isLoading={this.state.isLoading}
+          isLoading={isLoading}
           text="Signup"
           loadingText="Signing up…"
         />


### PR DESCRIPTION
Create Login screen. Using aws-amplify to support signIn. After login successfully, it will redirect to home page
![image](https://user-images.githubusercontent.com/84335186/118624896-c251aa80-b7f3-11eb-9c20-55c43d954fb7.png)

Added create New Note screen. Allow user to choose file and create new note. 
I'm reused the NoteDetail Component, it is a create new Note page when go to link http://localhost:3000/notes/new, it í a detail page when go to http://localhost:3000/notes/:id
Using s3upload to upload file. Currently, the call to cognito to upload file return 400.
![image](https://user-images.githubusercontent.com/84335186/118625671-6a677380-b7f4-11eb-8626-c68defa12a03.png)

![image](https://user-images.githubusercontent.com/84335186/118625292-15c3f880-b7f4-11eb-9ad5-fd9a2f3f28cc.png)
